### PR TITLE
add endpoint specific middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -777,9 +777,13 @@ lazy val guides = projectMatrix
   .in(file("modules/guides"))
   .dependsOn(http4s)
   .settings(
-    Compile / allowedNamespaces := Seq("smithy4s.guides.hello"),
+    Compile / allowedNamespaces := Seq(
+      "smithy4s.guides.hello",
+      "smithy4s.guides.auth"
+    ),
     smithySpecs := Seq(
-      (ThisBuild / baseDirectory).value / "modules" / "guides" / "smithy" / "hello.smithy"
+      (ThisBuild / baseDirectory).value / "modules" / "guides" / "smithy" / "hello.smithy",
+      (ThisBuild / baseDirectory).value / "modules" / "guides" / "smithy" / "auth.smithy"
     ),
     (Compile / sourceGenerators) := Seq(genSmithyScala(Compile).taskValue),
     isCE3 := true,

--- a/build.sbt
+++ b/build.sbt
@@ -789,6 +789,7 @@ lazy val guides = projectMatrix
     isCE3 := true,
     libraryDependencies ++= Seq(
       Dependencies.Http4s.emberServer.value,
+      Dependencies.Http4s.emberClient.value,
       Dependencies.Weaver.cats.value % Test
     )
   )

--- a/modules/guides/smithy/auth.smithy
+++ b/modules/guides/smithy/auth.smithy
@@ -5,7 +5,7 @@ namespace smithy4s.guides.auth
 use alloy#simpleRestJson
 
 @simpleRestJson
-@httpBearerAuth // add this here
+@httpBearerAuth
 service HelloWorldAuthService {
   version: "1.0.0",
   operations: [SayWorld, HealthCheck]

--- a/modules/guides/smithy/auth.smithy
+++ b/modules/guides/smithy/auth.smithy
@@ -1,0 +1,41 @@
+$version: "2"
+
+namespace smithy4s.guides.auth
+
+use alloy#simpleRestJson
+
+@simpleRestJson
+@httpBearerAuth // add this here
+service HelloWorldAuthService {
+  version: "1.0.0",
+  operations: [SayWorld, HealthCheck]
+  errors: [NotAuthorizedError]
+}
+
+
+@readonly
+@http(method: "GET", uri: "/hello", code: 200)
+operation SayWorld {
+  output: World
+}
+
+@readonly
+@http(method: "GET", uri: "/health", code: 200)
+@auth([])
+operation HealthCheck {
+  output := {
+    @required
+    message: String
+  }
+}
+
+structure World {
+  message: String = "World !"
+}
+
+@error("client")
+@httpError(401)
+structure NotAuthorizedError {
+  @required
+  message: String
+}

--- a/modules/guides/src/smithy4s/guides/Auth.scala
+++ b/modules/guides/src/smithy4s/guides/Auth.scala
@@ -97,8 +97,8 @@ object AuthMiddleware {
 
   def smithy4sMiddleware(
       authChecker: AuthChecker
-  ): EndpointSpecificMiddleware.Simple[HelloWorldAuthServiceGen, IO] =
-    new EndpointSpecificMiddleware.Simple[HelloWorldAuthServiceGen, IO] {
+  ): EndpointSpecificMiddleware.Simple[IO] =
+    new EndpointSpecificMiddleware.Simple[IO] {
       def prepareUsingHints(
           serviceHints: Hints,
           endpointHints: Hints

--- a/modules/guides/src/smithy4s/guides/Auth.scala
+++ b/modules/guides/src/smithy4s/guides/Auth.scala
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2021-2022 Disney Streaming
+ *
+ *  Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package smithy4s.guides
+
+import smithy4s.guides.auth._
+import cats.effect._
+import cats.implicits._
+import org.http4s.implicits._
+import org.http4s.ember.server._
+import org.http4s._
+import com.comcast.ip4s._
+import smithy4s.http4s.SimpleRestJsonBuilder
+import org.http4s.server.Middleware
+import org.typelevel.ci.CIString
+import scala.concurrent.duration.Duration
+import smithy4s.kinds.{FunctorAlgebra, PolyFunction5, Kind1}
+import smithy4s.Hints
+import org.http4s.headers.Authorization
+import cats.data.OptionT
+
+final case class APIKey(value: String)
+
+object HelloWorldAuthImpl extends HelloWorldAuthService[IO] {
+  def sayWorld(): IO[World] = World().pure[IO]
+  def healthCheck(): IO[HealthCheckOutput] = HealthCheckOutput("Okay!").pure[IO]
+}
+
+trait AuthChecker {
+  def isAuthorized(token: APIKey): IO[Boolean]
+}
+
+object AuthChecker extends AuthChecker {
+  def isAuthorized(token: APIKey): IO[Boolean] = {
+    IO.pure(
+      token.value.nonEmpty
+    ) // put your logic here, currently just makes sure the token is not empty
+  }
+}
+
+object AuthExampleRoutes {
+  import org.http4s.server.middleware._
+
+  private val helloRoutes: Resource[IO, HttpRoutes[IO]] =
+    SimpleRestJsonBuilder
+      .routes(HelloWorldAuthImpl)
+      .middleware(AuthMiddleware.smithy4sMiddleware(AuthChecker))
+      .resource
+
+  val all: Resource[IO, HttpRoutes[IO]] =
+    helloRoutes
+}
+
+object AuthMiddleware {
+
+  private def middleware(
+      authChecker: AuthChecker
+  ): HttpApp[IO] => HttpApp[IO] = { inputApp =>
+    HttpApp[IO] { request =>
+      val maybeKey = request.headers
+        .get[`Authorization`]
+        .collect {
+          case Authorization(
+                Credentials.Token(AuthScheme.Bearer, value)
+              ) =>
+            value
+        }
+        .map { APIKey.apply }
+
+      val isAuthorized = maybeKey
+        .map { key =>
+          authChecker.isAuthorized(key)
+        }
+        .getOrElse(IO.pure(false))
+
+      isAuthorized.flatMap {
+        case true => inputApp(request)
+        case false =>
+          IO.raiseError(new NotAuthorizedError("Not authorized!"))
+      }
+    }
+  }
+
+  def smithy4sMiddleware(
+      authChecker: AuthChecker
+  ): smithy4s.http4s.EndpointSpecificMiddleware[HelloWorldAuthServiceGen, IO] =
+    new smithy4s.http4s.EndpointSpecificMiddleware[
+      HelloWorldAuthServiceGen,
+      IO
+    ] {
+      def prepare(service: smithy4s.Service[HelloWorldAuthServiceGen])(
+          endpoint: smithy4s.Endpoint[service.Operation, _, _, _, _, _]
+      ): HttpApp[IO] => HttpApp[IO] = {
+        service.hints.get[smithy.api.HttpBearerAuth] match {
+          case Some(_) =>
+            val mid = middleware(authChecker)
+            endpoint.hints.get[smithy.api.Auth] match {
+              case Some(auths) if auths.value.isEmpty => identity
+              case _                                  => mid
+            }
+          case None => identity
+        }
+      }
+    }
+}
+
+// test with `curl localhost:9000/hello -H 'Authorization: Bearer Some'`
+// or `curl localhost:9000/hello`
+object AuthExampleMain extends IOApp.Simple {
+  val run = (for {
+    routes <- AuthExampleRoutes.all
+    server <- EmberServerBuilder
+      .default[IO]
+      .withPort(port"9000")
+      .withHost(host"localhost")
+      .withHttpApp(routes.orNotFound)
+      .build
+  } yield server).useForever
+}

--- a/modules/http4s/src-ce3/Compat.scala
+++ b/modules/http4s/src-ce3/Compat.scala
@@ -18,7 +18,7 @@ package smithy4s.http4s
 
 private[smithy4s] object Compat {
   trait Package {
-    private[smithy4s] type EffectCompat[F[_]] = cats.effect.Concurrent[F]
-    private[smithy4s] val EffectCompat = cats.effect.Concurrent
+    private[smithy4s] type EffectCompat[F[_]] = cats.effect.Async[F]
+    private[smithy4s] val EffectCompat = cats.effect.Async
   }
 }

--- a/modules/http4s/src/smithy4s/http4s/EndpointBasedMiddleware.scala
+++ b/modules/http4s/src/smithy4s/http4s/EndpointBasedMiddleware.scala
@@ -1,0 +1,26 @@
+package smithy4s
+package http4s
+
+import org.http4s.HttpApp
+
+// format: off
+trait EndpointSpecificMiddleware[Alg[_[_, _, _, _, _]], F[_]] {
+  def prepare(service: Service[Alg])(
+      endpoint: Endpoint[service.Operation, _, _, _, _, _]
+  ): HttpApp[F] => HttpApp[F]
+}
+// format: on
+
+object EndpointSpecificMiddleware {
+
+  private[http4s] type EndpointMiddleware[F[_], Op[_, _, _, _, _]] =
+    Endpoint[Op, _, _, _, _, _] => HttpApp[F] => HttpApp[F]
+
+  def noop[Alg[_[_, _, _, _, _]], F[_]]: EndpointSpecificMiddleware[Alg, F] =
+    new EndpointSpecificMiddleware[Alg, F] {
+      override def prepare(service: Service[Alg])(
+          endpoint: Endpoint[service.Operation, _, _, _, _, _]
+      ): HttpApp[F] => HttpApp[F] = identity
+    }
+
+}

--- a/modules/http4s/src/smithy4s/http4s/EndpointSpecificMiddleware.scala
+++ b/modules/http4s/src/smithy4s/http4s/EndpointSpecificMiddleware.scala
@@ -13,6 +13,19 @@ trait EndpointSpecificMiddleware[Alg[_[_, _, _, _, _]], F[_]] {
 
 object EndpointSpecificMiddleware {
 
+  trait Simple[Alg[_[_, _, _, _, _]], F[_]]
+      extends EndpointSpecificMiddleware[Alg, F] {
+    def prepareUsingHints(
+        serviceHints: Hints,
+        endpointHints: Hints
+    ): HttpApp[F] => HttpApp[F]
+
+    final def prepare(service: Service[Alg])(
+        endpoint: Endpoint[service.Operation, _, _, _, _, _]
+    ): HttpApp[F] => HttpApp[F] =
+      prepareUsingHints(service.hints, endpoint.hints)
+  }
+
   private[http4s] type EndpointMiddleware[F[_], Op[_, _, _, _, _]] =
     Endpoint[Op, _, _, _, _, _] => HttpApp[F] => HttpApp[F]
 

--- a/modules/http4s/src/smithy4s/http4s/EndpointSpecificMiddleware.scala
+++ b/modules/http4s/src/smithy4s/http4s/EndpointSpecificMiddleware.scala
@@ -4,8 +4,8 @@ package http4s
 import org.http4s.HttpApp
 
 // format: off
-trait EndpointSpecificMiddleware[Alg[_[_, _, _, _, _]], F[_]] {
-  def prepare(service: Service[Alg])(
+trait EndpointSpecificMiddleware[F[_]] {
+  def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
       endpoint: Endpoint[service.Operation, _, _, _, _, _]
   ): HttpApp[F] => HttpApp[F]
 }
@@ -13,14 +13,13 @@ trait EndpointSpecificMiddleware[Alg[_[_, _, _, _, _]], F[_]] {
 
 object EndpointSpecificMiddleware {
 
-  trait Simple[Alg[_[_, _, _, _, _]], F[_]]
-      extends EndpointSpecificMiddleware[Alg, F] {
+  trait Simple[F[_]] extends EndpointSpecificMiddleware[F] {
     def prepareUsingHints(
         serviceHints: Hints,
         endpointHints: Hints
     ): HttpApp[F] => HttpApp[F]
 
-    final def prepare(service: Service[Alg])(
+    final def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
         endpoint: Endpoint[service.Operation, _, _, _, _, _]
     ): HttpApp[F] => HttpApp[F] =
       prepareUsingHints(service.hints, endpoint.hints)
@@ -29,9 +28,9 @@ object EndpointSpecificMiddleware {
   private[http4s] type EndpointMiddleware[F[_], Op[_, _, _, _, _]] =
     Endpoint[Op, _, _, _, _, _] => HttpApp[F] => HttpApp[F]
 
-  def noop[Alg[_[_, _, _, _, _]], F[_]]: EndpointSpecificMiddleware[Alg, F] =
-    new EndpointSpecificMiddleware[Alg, F] {
-      override def prepare(service: Service[Alg])(
+  def noop[F[_]]: EndpointSpecificMiddleware[F] =
+    new EndpointSpecificMiddleware[F] {
+      override def prepare[Alg[_[_, _, _, _, _]]](service: Service[Alg])(
           endpoint: Endpoint[service.Operation, _, _, _, _, _]
       ): HttpApp[F] => HttpApp[F] = identity
     }

--- a/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
+++ b/modules/http4s/src/smithy4s/http4s/SimpleProtocolBuilder.scala
@@ -49,7 +49,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       service,
       impl,
       PartialFunction.empty,
-      EndpointSpecificMiddleware.noop[Alg, F]
+      EndpointSpecificMiddleware.noop[F]
     )
   }
 
@@ -67,7 +67,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
         service,
         impl,
         PartialFunction.empty,
-        EndpointSpecificMiddleware.noop[Alg, F]
+        EndpointSpecificMiddleware.noop[F]
       )
 
   }
@@ -111,7 +111,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       service: smithy4s.Service[Alg],
       impl: FunctorAlgebra[Alg, F],
       errorTransformation: PartialFunction[Throwable, F[Throwable]],
-      middleware: EndpointSpecificMiddleware[Alg, F]
+      middleware: EndpointSpecificMiddleware[F]
   )(implicit
       F: EffectCompat[F]
   ) {
@@ -130,7 +130,7 @@ abstract class SimpleProtocolBuilder[P](val codecs: CodecAPI)(implicit
       new RouterBuilder(service, impl, fe, middleware)
 
     def middleware(
-        mid: EndpointSpecificMiddleware[Alg, F]
+        mid: EndpointSpecificMiddleware[F]
     ): RouterBuilder[Alg, F] =
       new RouterBuilder[Alg, F](service, impl, errorTransformation, mid)
 

--- a/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/SmithyHttp4sReverseRouter.scala
@@ -27,7 +27,8 @@ class SmithyHttp4sReverseRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
     baseUri: Uri,
     service: smithy4s.Service.Aux[Alg, Op],
     client: Client[F],
-    entityCompiler: EntityCompiler[F]
+    entityCompiler: EntityCompiler[F],
+    middleware: EndpointSpecificMiddleware[F]
 )(implicit effect: EffectCompat[F])
     extends FunctorInterpreter[Op, F] {
 // format: on
@@ -55,7 +56,8 @@ class SmithyHttp4sReverseRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
             baseUri,
             client,
             endpoint,
-            compilerContext
+            compilerContext,
+            middleware.prepare(service)(endpoint)
           )
           .left
           .map { e =>

--- a/modules/http4s/src/smithy4s/http4s/SmithyHttp4sRouter.scala
+++ b/modules/http4s/src/smithy4s/http4s/SmithyHttp4sRouter.scala
@@ -34,7 +34,7 @@ class SmithyHttp4sRouter[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]](
     impl: FunctorInterpreter[Op, F],
     errorTransformation: PartialFunction[Throwable, F[Throwable]],
     entityCompiler: EntityCompiler[F],
-    middleware: EndpointSpecificMiddleware[Alg, F]
+    middleware: EndpointSpecificMiddleware[F]
 )(implicit effect: EffectCompat[F]) {
 
   private val pathParamsKey = {

--- a/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
+++ b/modules/http4s/src/smithy4s/http4s/internals/SmithyHttp4sServerEndpoint.scala
@@ -31,6 +31,8 @@ import smithy4s.http.Metadata
 import smithy4s.http._
 import smithy4s.schema.Alt
 import smithy4s.kinds._
+import org.http4s.HttpApp
+import org.typelevel.vault.Key
 
 /**
   * A construct that encapsulates a smithy4s endpoint, and exposes
@@ -39,7 +41,7 @@ import smithy4s.kinds._
 private[http4s] trait SmithyHttp4sServerEndpoint[F[_]] {
   def method: org.http4s.Method
   def matches(path: Array[String]): Option[PathParams]
-  def run(pathParams: PathParams, request: Request[F]): F[Response[F]]
+  def httpApp: HttpApp[F]
 
   def matchTap(
       path: Array[String]
@@ -49,15 +51,19 @@ private[http4s] trait SmithyHttp4sServerEndpoint[F[_]] {
 
 private[http4s] object SmithyHttp4sServerEndpoint {
 
+  // format: off
   def make[F[_]: EffectCompat, Op[_, _, _, _, _], I, E, O, SI, SO](
       impl: FunctorInterpreter[Op, F],
       endpoint: Endpoint[Op, I, E, O, SI, SO],
       compilerContext: CompilerContext[F],
-      errorTransformation: PartialFunction[Throwable, F[Throwable]]
+      errorTransformation: PartialFunction[Throwable, F[Throwable]],
+      middleware: EndpointSpecificMiddleware.EndpointMiddleware[F, Op],
+      pathParamsKey: Key[PathParams]
   ): Either[
     HttpEndpoint.HttpEndpointError,
     SmithyHttp4sServerEndpoint[F]
   ] =
+  // format: on
     HttpEndpoint.cast(endpoint).flatMap { httpEndpoint =>
       toHttp4sMethod(httpEndpoint.method)
         .leftMap { e =>
@@ -72,7 +78,9 @@ private[http4s] object SmithyHttp4sServerEndpoint {
             method,
             httpEndpoint,
             compilerContext,
-            errorTransformation
+            errorTransformation,
+            middleware,
+            pathParamsKey
           )
         }
     }
@@ -87,6 +95,8 @@ private[http4s] class SmithyHttp4sServerEndpointImpl[F[_], Op[_, _, _, _, _], I,
     httpEndpoint: HttpEndpoint[I],
     compilerContext: CompilerContext[F],
     errorTransformation: PartialFunction[Throwable, F[Throwable]],
+    middleware: EndpointSpecificMiddleware.EndpointMiddleware[F, Op],
+    pathParamsKey: Key[PathParams]
 )(implicit F: EffectCompat[F]) extends SmithyHttp4sServerEndpoint[F] {
 // format: on
   import compilerContext._
@@ -97,18 +107,22 @@ private[http4s] class SmithyHttp4sServerEndpointImpl[F[_], Op[_, _, _, _, _], I,
     httpEndpoint.matches(path)
   }
 
-  def run(pathParams: PathParams, request: Request[F]): F[Response[F]] = {
-    val run: F[O] = for {
-      metadata <- getMetadata(pathParams, request)
-      input <- extractInput(metadata, request)
-      output <- (impl(endpoint.wrap(input)): F[O])
-    } yield output
+  private val applyMiddleware = middleware(endpoint)
 
-    run.recoverWith(transformError).attempt.flatMap {
-      case Left(error)   => errorResponse(error)
-      case Right(output) => successResponse(output)
-    }
-  }
+  override val httpApp: HttpApp[F] =
+    applyMiddleware(HttpApp[F] { req =>
+      val pathParams = req.attributes.lookup(pathParamsKey).getOrElse(Map.empty)
+
+      val run: F[O] = for {
+        metadata <- getMetadata(pathParams, req)
+        input <- extractInput(metadata, req)
+        output <- (impl(endpoint.wrap(input)): F[O])
+      } yield output
+
+      run
+        .recoverWith(transformError)
+        .flatMap(successResponse)
+    }).handleErrorWith(error => Kleisli.liftF(errorResponse(error)))
 
   private val inputSchema: Schema[I] = endpoint.input
   private val outputSchema: Schema[O] = endpoint.output


### PR DESCRIPTION
Adds the ability to provide a middleware that can provide `HttpApp[F] => HttpApp[F]` conversions based on the data contained in the service and endpoint (such as Hints). This will allow more idiomatic implementations of things such as authentication/authorization and other mechanisms that rely on inspecting traits on a per-endpoint basis.

More docs to come as part of the PR.